### PR TITLE
Docker: Add laravel setup steps and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ como se muestra en [`docker/Docker.md`](docker/Docker.md).
 
 ```shell
 git clone https://github.com/MiguelAngelMP10/api-descargar-cfdi.git
-cd git clone https://github.com/MiguelAngelMP10/api-descargar-cfdi.git
+cd api-descargar-cfdi
 docker build -t api-descargar-cfdi -f docker/Dockerfile .
 docker run --name=api-descargar-cfdi --detach=true --publish 8081:80 \
   --volume $HOME/api-descargar-cfdi-data:/opt/api-descargar-cfdi/storage/app/datos/ \

--- a/docker/Docker.md
+++ b/docker/Docker.md
@@ -22,7 +22,7 @@ Sin necesidad de construir y mantener la imagen localmente.
 Comandos relacionados con la construcción de la imagen local.
 
 ```shell
-# construir la imagen
+# construir la imagen (usar --no-cache para forzar la reconstrucción)
 docker build -t api-descargar-cfdi -f docker/Dockerfile .
 
 # eliminar la imagen
@@ -45,6 +45,9 @@ docker run --name=api-descargar-cfdi \
 # iniciar y detener el contenedor
 docker stop api-descargar-cfdi
 docker start api-descargar-cfdi
+
+# entrar con una sesión de bash
+docker exec -it api-descargar-cfdi /bin/bash
 
 # eliminar el contenedor
 docker rm api-descargar-cfdi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,20 +6,23 @@ RUN set -e \
     && apt-get dist-upgrade -y \
     && apt-get install -y supervisor zip unzip git wget \
     && wget -q -O - https://packages.sury.org/php/README.txt | bash \
-    && apt-get install -y php-cli php-zip php-mbstring php-xml \
+    && apt-get install -y php-cli composer php-zip php-mbstring php-xml php-curl \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY . /opt/api-descargar-cfdi
 WORKDIR /opt/api-descargar-cfdi
 
 RUN set -e \
     && export COMPOSER_ALLOW_SUPERUSER=1 \
+    && composer diagnose \
     && composer install --no-interaction --prefer-dist --no-dev --optimize-autoloader \
     && rm -rf "$(composer config cache-dir --global)" "$(composer config data-dir --global)" "$(composer config home --global)"
+
+RUN set -e \
+    && cp .env.example .env \
+    && php artisan key:generate
 
 EXPOSE 80
 


### PR DESCRIPTION
Currently, the created docker image is not working, only needs to follow the steps to setup laravel, but itthis PR includes also other improvements.

- Install composer from apt
- Include php-curl for better performance
- Include php-zip for better performance
- Show composer diagnose results
- Setup .env file based on .env.example
- Generate .env key
