### PR TITLE
refactor: added form validation for certs

### DIFF
--- a/app/Http/Controllers/api/v1/SendCerKeyController.php
+++ b/app/Http/Controllers/api/v1/SendCerKeyController.php
@@ -4,13 +4,13 @@ namespace App\Http\Controllers\api\v1;
 
 use App\Helpers\SatWsService;
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use App\Http\Requests\SendCerKeyRequest;
 use Throwable;
 
 class SendCerKeyController extends Controller
 {
 
-    public function sendCerKey(Request $request)
+    public function sendCerKey(SendCerKeyRequest $request)
     {
         $satWsService = new SatWsService();
         try {

--- a/app/Http/Requests/SendCerKeyRequest.php
+++ b/app/Http/Requests/SendCerKeyRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class SendCerKeyRequest extends FormRequest
+{
+    protected $stopOnFirstFailure = false;
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'password' => ['required', 'string'],
+            'key' => ['required', 'file', 'mimetypes:text/plain,application/octet-stream'],
+            'cer' => ['required', 'file', 'mimetypes:text/plain,application/octet-stream'],
+        ];
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        $response = [
+            'message' => 'Los datos enviados de certificado, llave privada o contraseña son inválidos.',
+            'errors' => $validator->errors(),
+        ];
+        throw new HttpResponseException(
+            response()->json($response, 422)
+        );
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'cer.mimetypes' => 'The certificate file has invalid type.',
+            'key.mimetypes' => 'The private key file has invalid type.',
+            'cer.file' => 'The certificate is not a file.',
+            'key.file' => 'The private key is not a file.',
+        ];
+    }
+}

--- a/tests/_files/plain-text.txt
+++ b/tests/_files/plain-text.txt
@@ -1,0 +1,1 @@
+this is a plain text file


### PR DESCRIPTION
Se agrego una validación de seguridad para el envío de datos a la hora de registrar certificado, llave privada y contraseña.