### PR TITLE
Cambiar de ubicación los paquetes descargados

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,13 @@ composer install
 
 * Lista de endPoints
    ```
-    - /api/v1/send-cer-key
-    - /api/v1/make-query
-    - /api/v1/verify-query
-    - /api/v1/download-packages
+    - POST /api/v1/send-cer-key
+    - POST /api/v1/make-query
+    - POST /api/v1/verify-query
+    - POST /api/v1/download-packages
+    - GET /api/v1/packages/{rfc}
+    - GET /api/v1/packages/{rfc}/{packageId}
+    - DELETE /api/v1/packages/{rfc}/{packageId}
     ```
     
 

--- a/app/Helpers/SatWsService.php
+++ b/app/Helpers/SatWsService.php
@@ -6,6 +6,7 @@ namespace App\Helpers;
 
 use Exception;
 use Illuminate\Support\Facades\Storage;
+use PhpCfdi\Rfc\Rfc;
 use PhpCfdi\SatWsDescargaMasiva\RequestBuilder\FielRequestBuilder\Fiel;
 use PhpCfdi\SatWsDescargaMasiva\RequestBuilder\FielRequestBuilder\FielRequestBuilder;
 use PhpCfdi\SatWsDescargaMasiva\Service;
@@ -17,6 +18,9 @@ class SatWsService
 {
     public function createService(string $rfc, string $password, bool $retenciones): Service
     {
+        // parse will throw an exception if rfc is incorrect
+        $rfc = Rfc::parse($rfc)->getRfc();
+
         $contentCer = Storage::get($this->obtainCertificatePath($rfc));
         $contentKey = Storage::get($this->obtainPrivateKeyPath($rfc));
 

--- a/app/Helpers/SatWsService.php
+++ b/app/Helpers/SatWsService.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Storage;
 use PhpCfdi\SatWsDescargaMasiva\RequestBuilder\FielRequestBuilder\Fiel;
 use PhpCfdi\SatWsDescargaMasiva\RequestBuilder\FielRequestBuilder\FielRequestBuilder;
 use PhpCfdi\SatWsDescargaMasiva\Service;
+use PhpCfdi\SatWsDescargaMasiva\Services\Download\DownloadResult;
 use PhpCfdi\SatWsDescargaMasiva\Shared\ServiceEndpoints;
 use PhpCfdi\SatWsDescargaMasiva\WebClient\GuzzleWebClient;
 
@@ -53,5 +54,19 @@ class SatWsService
     public function obtainPrivateKeyPath(string $rfc): string
     {
         return 'datos/' . $rfc . "/" . $rfc . '.key';
+    }
+
+    public function obtainPackagePath(string $rfc, string $packageId): string
+    {
+        if ($packageId !== '') {
+            $packageId = $packageId . '.zip';
+        }
+        return 'datos/' . $rfc . '/packages/' . $packageId;
+    }
+
+    public function storePackage(string $rfc, string $packageId, DownloadResult $package): void
+    {
+        $path = $this->obtainPackagePath($rfc, $packageId);
+        Storage::put($path, $package->getPackageContent());
     }
 }

--- a/app/Http/Controllers/api/v1/DownloadPackagesController.php
+++ b/app/Http/Controllers/api/v1/DownloadPackagesController.php
@@ -16,7 +16,7 @@ class DownloadPackagesController extends Controller
         $satWsServiceHelper = new SatWsService();
         try {
             $service = $satWsServiceHelper->createService(
-                $request->input('RFC'),
+                $rfc = $request->input('RFC'),
                 $request->input('password'),
                 $request->boolean('retenciones')
             );
@@ -33,8 +33,7 @@ class DownloadPackagesController extends Controller
                 $errorMessages[] =  "El paquete {$packageId} no se ha podido descargar: {$download->getStatus()->getMessage()}";
                 continue;
             }
-            $zipfile = "$packageId.zip";
-            file_put_contents($zipfile, $download->getPackageContent());
+            $satWsServiceHelper->storePackage($rfc, $packageId, $download);
             $messages[] =  "El paquete {$packageId} se ha almacenado";
         }
         return response()->json(['errorMessages' => $errorMessages, 'messages' => $messages]);

--- a/app/Http/Controllers/api/v1/PackagesController.php
+++ b/app/Http/Controllers/api/v1/PackagesController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\api\v1;
+
+use App\Helpers\SatWsService;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Storage;
+use PhpCfdi\Rfc\Rfc;
+
+class PackagesController extends Controller
+{
+    public function index(Rfc $rfc)
+    {
+        $satWsServiceHelper = new SatWsService();
+        $path = $satWsServiceHelper->obtainPackagePath($rfc->getRfc(), '');
+        $packageIds = [];
+        foreach (Storage::files($path) as $packageFile) {
+            $packageIds[] = substr(basename($packageFile), 0, -4);
+        }
+        return response()->json([
+            'rfc' => $rfc,
+            'packages' => $packageIds
+        ]);
+    }
+
+    public function download(Rfc $rfc, string $packageId)
+    {
+        $satWsServiceHelper = new SatWsService();
+        $path = $satWsServiceHelper->obtainPackagePath($rfc->getRfc(), $packageId);
+        if (! Storage::exists($path)) {
+            return response()->json(['message' => "Package $rfc/$packageId not found."], 404);
+        }
+        return Storage::response($path);
+    }
+
+    public function delete(Rfc $rfc, string $packageId)
+    {
+        $satWsServiceHelper = new SatWsService();
+        $path = $satWsServiceHelper->obtainPackagePath($rfc->getRfc(), $packageId);
+        if (Storage::exists($path)) {
+            Storage::delete($path);
+        }
+        return response(null, 204);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^8.12",
         "laravel/tinker": "^2.5",
+        "phpcfdi/rfc": "^1.1",
         "phpcfdi/sat-ws-descarga-masiva": "^0.4.2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef6096c1e7941a5db467c8f48b17a655",
+    "content-hash": "2242bcacdf99ab2bf2b1f8a0f0f64da1",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2134,6 +2134,58 @@
                 "source": "https://github.com/phpcfdi/credentials"
             },
             "time": "2020-12-21T03:06:48+00:00"
+        },
+        {
+            "name": "phpcfdi/rfc",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpcfdi/rfc.git",
+                "reference": "a4aa353dded23a72e1887763d2848bd196e63fba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpcfdi/rfc/zipball/a4aa353dded23a72e1887763d2848bd196e63fba",
+                "reference": "a4aa353dded23a72e1887763d2848bd196e63fba",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "fakerphp/faker": "^1.13",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpCfdi\\Rfc\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Carlos C Soto",
+                    "email": "eclipxe13@gmail.com",
+                    "homepage": "http://eclipxe.com.mx/"
+                }
+            ],
+            "description": "PHP library to deal with Mexican RFC",
+            "homepage": "https://github.com/phpcfdi/rfc",
+            "keywords": [
+                "mexico",
+                "sat"
+            ],
+            "support": {
+                "issues": "https://github.com/phpcfdi/rfc/issues",
+                "source": "https://github.com/phpcfdi/rfc"
+            },
+            "time": "2021-03-16T22:58:06+00:00"
         },
         {
             "name": "phpcfdi/sat-ws-descarga-masiva",

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,13 +1,15 @@
 <?php
 
 use App\Http\Controllers\api\v1\DownloadPackagesController;
+use App\Http\Controllers\api\v1\PackagesController;
 use App\Http\Controllers\api\v1\MakeQueryController;
 use App\Http\Controllers\api\v1\SendCerKeyController;
 use App\Http\Controllers\api\v1\VerifyQueryController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-
-
+use PhpCfdi\Rfc\Exceptions\InvalidExpressionToParseException;
+use PhpCfdi\Rfc\Rfc;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /*
 |--------------------------------------------------------------------------
@@ -32,3 +34,18 @@ Route::post('v1/make-query', [MakeQueryController::class, 'makeQuery']);
 Route::post('v1/verify-query', [VerifyQueryController::class, 'verifyQuery']);
 
 Route::post('v1/download-packages', [DownloadPackagesController::class, 'downloadPackages']);
+
+Route::get('v1/{rfc}/packages', [PackagesController::class, 'index']);
+Route::get('v1/{rfc}/packages/{packageId}', [PackagesController::class, 'download']);
+Route::delete('v1/{rfc}/packages/{packageId}', [PackagesController::class, 'delete']);
+
+/*
+ * convert routes `{rfc}` parameter to `Rfc` object
+ */
+Route::bind('rfc', function (string $value): Rfc {
+    try {
+        return Rfc::parse($value);
+    } catch (InvalidExpressionToParseException $exception) {
+        throw new NotFoundHttpException("Invalid RFC value $value.");
+    }
+});

--- a/tests/Feature/RetrievePackagesTest.php
+++ b/tests/Feature/RetrievePackagesTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Helpers\SatWsService;
+use App\Http\Controllers\api\v1\PackagesController;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+final class RetrievePackagesTest extends TestCase
+{
+    use WithFaker;
+
+    /** @var SatWsService */
+    private $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new SatWsService();
+    }
+
+    private function createPackageId(): string
+    {
+        return $this->faker->uuid;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function createPackages(string $rfc, int $count): array
+    {
+        $packages = [];
+        for ($i = 0; $i < $count; $i++) {
+            $packageId = $this->createPackageId();
+            $packagePath = $this->service->obtainPackagePath($rfc, $packageId);
+            Storage::put($packagePath, $this->faker->text);
+            $packages[$packageId] = $packagePath;
+        }
+        return $packages;
+    }
+
+    /**
+     * @see PackagesController::index()
+     * @test
+     */
+    public function list_of_empty_packages(): void
+    {
+        $rfc = 'AAAA010101AAA';
+        $response = $this->getJson("/api/v1/$rfc/packages");
+        $response->assertStatus(200);
+        $response->assertJson(['rfc' => $rfc], true);
+        $response->assertJsonCount(0, 'packages');
+    }
+
+    /**
+     * @see PackagesController::index()
+     * @test
+     */
+    public function list_of_packages(): void
+    {
+        Storage::fake('local');
+
+        $rfc = 'AAAA010101AAA';
+        $packageIds = array_keys($this->createPackages($rfc, 3));
+        sort($packageIds);
+
+        $response = $this->getJson("/api/v1/$rfc/packages");
+
+        $response->assertStatus(200);
+        $response->assertJson(['rfc' => $rfc, 'packages' => $packageIds]);
+        $response->assertJsonCount(3, 'packages');
+    }
+
+    /**
+     * @see PackagesController::index()
+     * @test
+     */
+    public function list_not_found_on_invalid_rfc(): void
+    {
+        $invalidRfc = 'invalid-rfc';
+
+        $response = $this->getJson("/api/v1/$invalidRfc/packages");
+
+        $response->assertStatus(404);
+        $response->assertJson(['message' => "Invalid RFC value $invalidRfc."]);
+    }
+
+    /**
+     * @see PackagesController::download()
+     * @test
+     */
+    public function download_a_package(): void
+    {
+        Storage::fake('local');
+
+        $rfc = 'AAAA010101AAA';
+        $packages = $this->createPackages($rfc, 1);
+        $packageId = array_key_first($packages);
+        $packagePath = $packages[$packageId];
+
+        $response = $this->get("/api/v1/$rfc/packages/$packageId");
+
+        $response->assertStatus(200);
+        $this->assertEquals(Storage::get($packagePath), $response->streamedContent());
+    }
+
+    /**
+     * @see PackagesController::download()
+     * @test
+     */
+    public function download_not_found_using_invalid_rfc(): void
+    {
+        $invalidRfc = 'invalid-rfc';
+        $packageId = $this->createPackageId();
+
+        $response = $this->getJson("/api/v1/$invalidRfc/packages/$packageId");
+
+        $response->assertStatus(404);
+        $response->assertJson(['message' => "Invalid RFC value $invalidRfc."]);
+    }
+
+    /**
+     * @see PackagesController::download()
+     * @test
+     */
+    public function download_not_found_on_non_existent_package(): void
+    {
+        Storage::fake('local');
+
+        $rfc = 'AAAA010101AAA';
+        $packageId = $this->createPackageId();
+
+        $response = $this->getJson("/api/v1/$rfc/packages/$packageId");
+
+        $response->assertStatus(404);
+        $response->assertJson(['message' => "Package $rfc/$packageId not found."]);
+    }
+
+    /**
+     * @see PackagesController::delete()
+     * @test
+     */
+    public function delete_ok_when_package_exists(): void
+    {
+        Storage::fake('local');
+
+        $rfc = 'AAAA010101AAA';
+        $packages = $this->createPackages($rfc, 1);
+        $packageId = array_key_first($packages);
+        $packagePath = $packages[$packageId];
+
+        $response = $this->deleteJson("/api/v1/$rfc/packages/$packageId");
+
+        $response->assertStatus(204);
+        Storage::assertMissing($packagePath);
+    }
+
+    /**
+     * @see PackagesController::delete()
+     * @test
+     */
+    public function delete_ok_when_package_does_not_exists(): void
+    {
+        $rfc = 'AAAA010101AAA';
+        $packageId = $this->createPackageId();
+
+        $response = $this->deleteJson("/api/v1/$rfc/packages/$packageId");
+
+        $response->assertStatus(204);
+    }
+
+    /**
+     * @see PackagesController::delete()
+     * @test
+     */
+    public function delete_not_found_on_invalid_rfc(): void
+    {
+        $invalidRfc = 'invalid-rfc';
+        $packageId = $this->createPackageId();
+
+        $response = $this->deleteJson("/api/v1/$invalidRfc/packages/$packageId");
+
+        $response->assertStatus(404);
+        $response->assertJson(['message' => "Invalid RFC value $invalidRfc."]);
+    }
+}


### PR DESCRIPTION
Los paquetes descargados actualmente se almacenan en `public/`

Con este cambio los paquetes ahora se decargarán en `storage/datos/{rfc}/packages/{packageId}.zip`

Los paquetes se pueden administrar con estos endpoints:

- `GET /api/v1/packages/{rfc}/` Listado de paquetes
- `GET /api/v1/packages/{rfc}/{packageId}` Descarga de un paquete
- `DELETE /api/v1/packages/{rfc}/{packageId}` Elimina un paquete del almacenamiento

Nota: **Este cambio rompe la compatibilidad con versiones previas**