### PR TITLE
Add GitHub actions for continuous integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main", "feature/*" ]
+
+jobs:
+  tests:
+    name: CI PHP ${{ matrix.php-versions }}
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        php-versions: [ '7.3', '7.4', '8.0' ]
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # see https://github.com/marketplace/actions/setup-php-action
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: json, mbstring, pdo, sqlite, pdo_sqlite
+          coverage: none
+          tools: composer:v2, cs2pr
+        env:
+          fail-fast: true
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Composer cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install project dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Set environment file
+        run: php -r "copy('.env.example', '.env');"
+
+      - name: Set Laravel application key
+        run: php artisan key:generate
+
+      - name: Tests (phpunit)
+        run: vendor/bin/phpunit --testdox --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install project dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
+        run: composer update --no-interaction --no-progress --prefer-dist
 
       - name: Set environment file
         run: php -r "copy('.env.example', '.env');"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: json, mbstring, pdo, sqlite, pdo_sqlite
+          extensions: json, mbstring
           coverage: none
-          tools: composer:v2, cs2pr
+          tools: composer:v2
         env:
           fail-fast: true
 


### PR DESCRIPTION
This will only act on branches: `master` & `feature/*`

It runs phpunit, if other tools are required (like php_codesniffer, larastan, phpinsights, etc.) please include them.


At this moment, the code style is failing!!

    ```
    # check errors
    vendor/bin/phpinsights analyse --min-style=100 --no-interaction
    
    # automatically fix code-style errors
    vendor/bin/phpinsights fix --no-interaction
    ```


Add the following code to include phpinsights code style 

    ```
      - name: PHP Insights
        run: vendor/bin/phpinsights analyse --min-style=100 --no-interaction --ansi --format=github-action
    ```
