### PR TITLE
Add GitHub action for continuous integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: PHP Insights
         run: vendor/bin/phpinsights analyse --min-style=100 --no-interaction --ansi --format=github-action
+        continue-on-error: true
 
       - name: Static analysis
         run: vendor/bin/phpstan analyse --verbose --no-progress --no-interaction --ansi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main", "feature/*" ]
+
+jobs:
+  tests:
+    name: CI PHP ${{ matrix.php-versions }}
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        php-versions: [ '7.3', '7.4', '8.0' ]
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # see https://github.com/marketplace/actions/setup-php-action
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: json, mbstring, pdo, sqlite, pdo_sqlite
+          coverage: none
+          tools: composer:v2, cs2pr
+        env:
+          fail-fast: true
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Composer cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install project dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Set environment file
+        run: php -r "copy('.env.example', '.env');"
+
+      - name: Set Laravel application key
+        run: php artisan key:generate
+
+      - name: Tests (phpunit)
+        run: vendor/bin/phpunit --testdox --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: vendor/bin/phpunit --testdox --verbose
 
       - name: PHP Insights
-        run: vendor/bin/phpinsights analyse --min-style=100 --no-interaction --ansi --format=github-action
+        run: php artisan insights --min-style=100 --no-interaction --ansi --format=github-action
         continue-on-error: true
 
       - name: Static analysis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,6 @@ jobs:
 
       - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --verbose
+
+      - name: PHP Insights
+        run: vendor/bin/phpinsights analyse --min-style=100 --no-interaction --ansi --format=github-action

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: vendor/bin/phpunit --testdox --verbose
 
       - name: PHP Insights
-        run: php artisan insights --min-style=100 --no-interaction --ansi --format=github-action
+        run: php artisan insights --no-interaction --ansi --format=github-action
         continue-on-error: true
 
       - name: Static analysis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install project dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
+        run: composer update --no-interaction --no-progress --prefer-dist
 
       - name: Set environment file
         run: php -r "copy('.env.example', '.env');"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,3 +56,6 @@ jobs:
 
       - name: PHP Insights
         run: vendor/bin/phpinsights analyse --min-style=100 --no-interaction --ansi --format=github-action
+
+      - name: Static analysis
+        run: vendor/bin/phpstan analyse --verbose --no-progress --no-interaction --ansi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: json, mbstring, pdo, sqlite, pdo_sqlite
+          extensions: json, mbstring
           coverage: none
-          tools: composer:v2, cs2pr
+          tools: composer:v2
         env:
           fail-fast: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contribuciones
+
+Las contribuciones son bienvenidas, te invitamos a enviarlas a través de un *pull request*, un *issue*
+o una *discusión* de GitHub. Te pedimos que sigas esta guía en caso de enviar un *pull request*.
+
+## Proceso
+
+1. Haz un *fork* del proyecto.
+1. Crea una nueva rama.
+1. Haz tu código, corre las pruebas y comparte tus cambios.
+1. En el *pull request* detalla los cambios.
+
+## Guía básica
+
+* Apégate al estándar de código del proyecto.
+* Asegúrate que las pruebas actuales son exitosas. Si has agregado algo crea las pruebas oportunas.
+* Envía una historia de *commits* coherente, haz cada *commit* en tu *pull request* tenga sentido.
+* Tal vez necesites hacer *[rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing)* para evitar *merge conflicts*.
+* Si estás cambiando el comportamiento o la API pública entonces cambia también la documentación.
+* Corre las revisiones en tu entorno de desarrollo antes de enviar tu *pull request*, asegúrate que tus pruebas son exitosas.
+
+## Revisiones de integración continua (CI)
+
+Este proyecto usa *GitHub Workflows* para el proceso de integración continua *(CI: Continuous Integration)* 
+
+El proceso de CI se ejecuta con todas las versiones de PHP con las que el proyecto es compatible.
+
+Si planeas enviar un *pull request* asegúrate que las revisiones del proceso de CI se ejecutan sin errores.
+Las revisiones las puedes ejecutar en tu entorno de desarrollo, sigue los comandos descritos en:
+*Estilo*, *Pruebas* y *Análisis estático*.
+
+### Estilo
+
+Apégate al estándar de código del proyecto, verificado usando [PHPInsights][].
+
+Para corregir el código automáticamente:
+
+```shell
+php artisan insights --fix --no-interaction
+```
+
+Para revisar el código que no sigue el estándar:
+
+```shell
+php artisan insights --no-interaction
+```
+
+### Pruebas
+
+El proyecto tiene diferentes tipos de pruebas, usamos [PHPUnit][] para escribirlas.
+
+```shell
+php artisan test
+```
+
+### Análisis estático
+
+El análisis estático de código puede ser muy útil para detectar errores y código defectuoso.
+Este proyecto usa *[PHPStan][]* a través de *[Larastan][]*.
+
+```shell
+php vendor/bin/phpstan analyse -v
+```
+
+[PHPInsights]: https://phpinsights.com/
+[PHPUnit]: https://phpunit.de/
+[PHPStan]: https://github.com/phpstan/phpstan
+[Larastan]: https://github.com/nunomaduro/larastan

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ docker run --name=api-descargar-cfdi --detach=true --publish 8081:80 \
   api-descargar-cfdi
 ```
 
+## Contribuciones
+
+Estamos abiertos a contribuciones de código, documentación, entorno de desarrollo, reporte de problemas,
+discusión de nuevas ideas, etc. Lee nuestra [guía de contribución](CONTRIBUTING.md).
+
 ## Copyright and License
 
 The `MiguelAngelMP10/api-descargar-cfdi` proyect is copyright © [Miguel Angel Muñoz Pozos](a)

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "mockery/mockery": "^1.4.2",
         "nunomaduro/collision": "^5.0",
         "nunomaduro/larastan": "^0.7.12",
-        "nunomaduro/phpinsights": "^2.0",
+        "nunomaduro/phpinsights": "^1.0|^2.0",
         "phpunit/phpunit": "^9.3.3",
         "squizlabs/php_codesniffer": "^3.6.0"
     },

--- a/config/insights.php
+++ b/config/insights.php
@@ -128,7 +128,7 @@ return [
         //        'min-quality' => 0,
         //        'min-complexity' => 0,
         //        'min-architecture' => 0,
-        //        'min-style' => 0,
+        'min-style' => 0, // full compliance required
         //        'disable-security-check' => false,
     ],
 


### PR DESCRIPTION
This will only act on branches: `master` & `feature/*`

Run the pipeline using PHP versions 7.3, 7.4 and 8.0.

Checks:

- PHPUnit
- PHPInsights (only enforce code style)
- PHPStan

Notes:

- This work flow uses `.env.example` to set up the project.
- It uses `composer update` (as opposite of `composer install`) since it fail depending on php version.

**NOTICE**

The current codebase is dirty.

Run `vendor/bin/phpinsights fix --no-interaction` to automatically fix most errors.

Run `vendor/bin/phpinsights analyse --no-interaction --min-style=100` to find the issues that have to me manually fixed.

Because of this problem, the workflow `PHPInsight` is allowed to fail. This should be removed.

**BEFORE MERGE**

Do you want me to repair the code base before merging this PR?

I think that also a `CONTRIBUTING.md` file is required to explain the build process to run it locally.
Should I include a `CONTRIBUTING.md` file on the project?
