### PR TITLE
CI is not failing due incorrect PHP Insights configuration

### DIFF
--- a/config/insights.php
+++ b/config/insights.php
@@ -128,7 +128,7 @@ return [
         //        'min-quality' => 0,
         //        'min-complexity' => 0,
         //        'min-architecture' => 0,
-        'min-style' => 0, // full compliance required
+        'min-style' => 100, // full compliance required
         //        'disable-security-check' => false,
     ],
 


### PR DESCRIPTION
Fix `requirements.min-style`: was `0` (no fail). Set to `100` (do not allow any errors)